### PR TITLE
Update webplib.py

### DIFF
--- a/webptools/webplib.py
+++ b/webptools/webplib.py
@@ -28,7 +28,7 @@ def cwebp(input_image: str, output_image: str, option: str) -> Dict:
 # output_image: output image(.jpeg, .pnp ....)
 # option: options and quality,it should be given between 0 to 100
 def dwebp(input_image: str, output_image: str, option: str) -> Dict:
-    cmd = f"{getdwebp()} {input_image} {option} {output_image}"
+    cmd = f'"{getdwebp()}" "{input_image}" "{option}" "{output_image}"'
     p = subprocess.Popen(cmd, shell=True, stdin=None, stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()


### PR DESCRIPTION
If the file name contains spaces, you should enclose it in double quotes because it fails to convert properly and an error occurs. I only modified the dwebp on a trial basis, so please review the rest and correct it.