### PR TITLE
fix #14: webpmux_animate not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Webptools v0.0.7](https://pypi.org/project/webptools/)
+[Webptools v0.0.8](https://pypi.org/project/webptools/)
 
 webptools is a Webp image conversion package for the python.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ from webptools import webpmux_add
 # for XMP metadata: xmp
 # for EXIF metadata: exif
 print(webpmux_add(input_image="in.webp", output_image="icc_container.webp",
-                  icc_profile="image_profile.icc", option="icc", logging="-v"))
+                  icc_profile="image_profile.icc", option="icc"))
 ```
 
 ## Extract ICC profile,XMP metadata and EXIF metadata
@@ -137,8 +137,7 @@ from webptools import webpmux_extract
 # for XMP metadata: xmp
 # for EXIF metadata: exif
 print(webpmux_extract(input_image="anim_container.webp",
-                      icc_profile="image_profile.icc", option="icc",
-                      logging="-v"))
+                      icc_profile="image_profile.icc", option="icc"))
 ```
 
 ## Strip ICC profile,XMP metadata and EXIF metadata
@@ -153,8 +152,7 @@ from webptools import webpmux_strip
 # for XMP metadata: xmp
 # for EXIF metadata: exif
 print(webpmux_strip(input_image="icc_container.webp",
-                    output_image="without_icc.webp", option="icc",
-                    logging="-v"))
+                    output_image="without_icc.webp", option="icc"))
 
 
 ```
@@ -198,7 +196,7 @@ from webptools import webpmux_animate
 input = ["./frames/tmp-0.webp +100", "./frames/tmp-1.webp +100",
          "./frames/tmp-2.webp +100"]
 print(webpmux_animate(input_images=input, output_image="anim_container.webp",
-                      loop="10", bgcolor="255,255,255,255", logging="-v"))
+                      loop="10", bgcolor="255,255,255,255"))
 
 ```
 
@@ -210,8 +208,7 @@ from webptools import webpmux_getframe
 
 # pass input_image(.webp image) path ,output_image and frame number
 print(webpmux_getframe(input_image="anim_container.webp",
-                       output_image="frame_2.webp", frame_number="2",
-                       logging="-v"))
+                       output_image="frame_2.webp", frame_number="2"))
 
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setuptools.setup(
     name="webptools",
-    version="0.0.7",
+    version="0.0.8",
     scripts=['webptools/webplib.py'],
     author="scionoftech",
     description="webptools is a Webp image conversion package for python",

--- a/webptools/webplib.py
+++ b/webptools/webplib.py
@@ -252,7 +252,7 @@ def webpmux_animate(input_images: List, output_image: str, loop: str,
     for frame in input_images:
         files += f" -frame {frame}"
 
-    cmd = f"{getwebpmux(bin_path=bin_path)} {files} -loop {loop} bgcolor {bgcolor} -o {output_image} {logging}"
+    cmd = f"{getwebpmux(bin_path=bin_path)} {files} -loop {loop} -bgcolor {bgcolor} -o {output_image} {logging}"
     p = subprocess.Popen(cmd, shell=True, stdin=None, stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()

--- a/webptools/webplib.py
+++ b/webptools/webplib.py
@@ -160,7 +160,7 @@ def gifwebp(input_image: str, output_image: str, option: str,
 # ****************** webpmux *********************** #
 
 def webpmux_add(input_image: str, output_image: str, icc_profile: str,
-                option: str, logging: str = "-v", bin_path: str = None) -> Dict:
+                option: str, logging: str = "", bin_path: str = None) -> Dict:
     """
     Add ICC profile,XMP metadata and EXIF metadata #
 
@@ -186,7 +186,7 @@ def webpmux_add(input_image: str, output_image: str, icc_profile: str,
 
 
 def webpmux_extract(input_image: str, icc_profile: str, option: str,
-                    logging: str = "-v", bin_path: str = None) -> Dict:
+                    logging: str = "", bin_path: str = None) -> Dict:
     """
     Extract ICC profile,XMP metadata and EXIF metadata
 
@@ -209,7 +209,7 @@ def webpmux_extract(input_image: str, icc_profile: str, option: str,
 
 
 def webpmux_strip(input_image: str, output_image: str, option: str,
-                  logging: str = "-v", bin_path: str = None) -> Dict:
+                  logging: str = "", bin_path: str = None) -> Dict:
     """
     Strip ICC profile,XMP metadata and EXIF metadata
 
@@ -232,7 +232,7 @@ def webpmux_strip(input_image: str, output_image: str, option: str,
 
 
 def webpmux_animate(input_images: List, output_image: str, loop: str,
-                    bgcolor: str, logging: str = "-v", bin_path: str = None) -> Dict:
+                    bgcolor: str, logging: str = "", bin_path: str = None) -> Dict:
     """
     Create an animated WebP file from Webp images
 
@@ -262,7 +262,7 @@ def webpmux_animate(input_images: List, output_image: str, loop: str,
 
 
 def webpmux_getframe(input_image: str, output_image: str,
-                     frame_number: str, logging: str = "-v", bin_path: str = None) -> Dict:
+                     frame_number: str, logging: str = "", bin_path: str = None) -> Dict:
     """
     Get the a frame from an animated WebP file
 


### PR DESCRIPTION
Add `-` before the `bgcolor` option.

Remove the `-v` flag, which is not supported by webpmux.

Bump version number to 0.0.8.

Fixes #14. This works for me, but you may want to double-check this; I'm not familiar with the project.